### PR TITLE
Use Registration sources instead of child lifetime scopes for additional registrations

### DIFF
--- a/Prism.Autofac.Mutable.Wpf/Ioc/AutofacContainerExtension.cs
+++ b/Prism.Autofac.Mutable.Wpf/Ioc/AutofacContainerExtension.cs
@@ -20,8 +20,7 @@ namespace Prism.Autofac.Mutable.Wpf.Ioc
                 return;
 
             Builder.RegisterSource(new AnyConcreteTypeNotAlreadyRegisteredSource());
-            var container = Builder.Build();
-            Instance = new MutableContainer(container);
+            Instance = new MutableContainer(Builder);
             FinalizeRegistry();
         }
 

--- a/Prism.Autofac.Mutable.Wpf/Ioc/ExternalRegistrySource.cs
+++ b/Prism.Autofac.Mutable.Wpf/Ioc/ExternalRegistrySource.cs
@@ -1,0 +1,91 @@
+﻿using Autofac.Core;
+using Autofac.Core.Activators.Delegate;
+using Autofac.Core.Lifetime;
+using Autofac.Core.Registration;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Prism.Autofac.Mutable.Wpf.Ioc
+{
+    /// <summary>
+    /// Taken from <see href="https://github.com/autofac/Autofac/blob/master/src/Autofac/Core/Registration/ExternalRegistrySource.cs">here</see>.
+    /// Pulls registrations from another component registry.
+    /// Excludes most auto-generated registrations - currently has issues with
+    /// collection registrations.
+    /// 
+    /// </summary>
+    internal class ExternalRegistrySource : IRegistrationSource
+    {
+        private readonly IComponentRegistry _registry;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExternalRegistrySource "/> class.
+        /// </summary>
+        /// <param name="registry">Component registry to pull registrations from.</param>
+        public ExternalRegistrySource(IComponentRegistry registry)
+        {
+            if (registry == null) throw new ArgumentNullException(nameof(registry));
+
+            _registry = registry;
+        }
+
+        /// <summary>
+        /// Retrieve registrations for an unregistered service, to be used
+        /// by the container.
+        /// </summary>
+        /// <param name="service">The service that was requested.</param>
+        /// <param name="registrationAccessor">A function that will return existing registrations for a service.</param>
+        /// <returns>Registrations providing the service.</returns>
+        public IEnumerable<IComponentRegistration> RegistrationsFor(Service service, Func<Service, IEnumerable<IComponentRegistration>> registrationAccessor)
+        {
+            // Issue #475: This method was refactored significantly to handle
+            // registrations made on the fly in parent lifetime scopes to correctly
+            // pass to child lifetime scopes.
+
+            // Issue #272: Taking from the registry the following registrations:
+            //   - non-adapting own registrations: wrap them with ExternalComponentRegistration
+            //   - if the registration is from the parent registry of this registry,
+            //     it is already wrapped with ExternalComponentRegistration,
+            //     share it as is
+            return _registry.RegistrationsFor(service)
+                .Where(r => r is ExternalComponentRegistration || r.Target == r)
+                .Select(r =>
+                    r as ExternalComponentRegistration ??
+
+                    // equivalent to following registation builder
+                    //    RegistrationBuilder.ForDelegate(r.Activator.LimitType, (c, p) => c.ResolveComponent(r, p))
+                    //        .Targeting(r)
+                    //        .As(service)
+                    //        .ExternallyOwned()
+                    //        .CreateRegistration()
+                    new ExternalComponentRegistration(
+                        Guid.NewGuid(),
+                        new DelegateActivator(r.Activator.LimitType, (c, p) => c.ResolveComponent(r, p)),
+                        new CurrentScopeLifetime(),
+                        InstanceSharing.None,
+                        InstanceOwnership.ExternallyOwned,
+                        new[] { service },
+                        r.Metadata,
+                        r));
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether components are adapted from the same logical scope.
+        /// In this case because the components that are adapted do not come from the same
+        /// logical scope, we must return false to avoid duplicating them.
+        /// </summary>
+        public bool IsAdapterForIndividualComponents => false;
+
+        /// <summary>
+        ///  ComponentRegistration subtyped only to distinguish it from other adapted registrations.
+        /// </summary>
+        private class ExternalComponentRegistration : ComponentRegistration
+        {
+            public ExternalComponentRegistration(Guid id, IInstanceActivator activator, IComponentLifetime lifetime, InstanceSharing sharing, InstanceOwnership ownership, IEnumerable<Service> services, IDictionary<string, object> metadata, IComponentRegistration target)
+                : base(id, activator, lifetime, sharing, ownership, services, metadata, target)
+            {
+            }
+        }
+    }
+}

--- a/Prism.Autofac.Mutable.Wpf/Ioc/MutableContainer.cs
+++ b/Prism.Autofac.Mutable.Wpf/Ioc/MutableContainer.cs
@@ -11,39 +11,39 @@ namespace Prism.Autofac.Mutable.Wpf.Ioc
     internal class MutableContainer : Disposable, IMutableContainer, IServiceProvider
     {
         private readonly IContainer _container;
+        private readonly IContainer _additionalRegistrationsContainer;
+        private readonly ILifetimeScope _lifetimeScope;
         private readonly List<ILifetimeScope> _managedChildScopes;
 
-        private ILifetimeScope _currentLifetimeScope;
-
-        internal MutableContainer(IContainer container)
+        internal MutableContainer(ContainerBuilder builder)
         {
-            _container = container;
+            builder.RegisterInstance(this).As<IMutableContainer>().As<IContainer>().SingleInstance();
+            _container = builder.Build();
+            _additionalRegistrationsContainer = new ContainerBuilder().Build();
             _managedChildScopes = new List<ILifetimeScope>();
-            _currentLifetimeScope = container.Resolve<ILifetimeScope>();
-            //Initialize child scope and register self.
-            RegisterTypes(b => b.RegisterInstance(this)
-                .As<IMutableContainer>()
-                .As<IContainer>());
+            _lifetimeScope = _container.Resolve<ILifetimeScope>();
+            _lifetimeScope.ChildLifetimeScopeBeginning += OnChildLifetimeScopeBeginning;
+            _lifetimeScope.CurrentScopeEnding += OnCurrentScopeEnding;
+            _lifetimeScope.ResolveOperationBeginning += OnResolveOperationBeginning;
         }
 
+        /// <summary>
+        /// Registers additional types to be made available in the container.
+        /// </summary>
+        /// <param name="configurationAction">Configuration for the <see cref="ContainerBuilder"/></param>
         public void RegisterTypes(Action<ContainerBuilder> configurationAction)
         {
             if (configurationAction == null)
                 throw new ArgumentNullException(nameof(configurationAction));
 
-            _currentLifetimeScope.ChildLifetimeScopeBeginning -= OnChildLifetimeScopeBeginning;
-            _currentLifetimeScope.CurrentScopeEnding -= OnCurrentScopeEnding;
-            _currentLifetimeScope.ResolveOperationBeginning -= OnResolveOperationBeginning;
-            _currentLifetimeScope = _currentLifetimeScope.BeginLifetimeScope(builder =>
-            {
-                builder.RegisterInstance(this).As<ILifetimeScope>().As<IComponentContext>();
-                configurationAction(builder);
-            });
-            _managedChildScopes.Add(_currentLifetimeScope);
+            var childScope = _additionalRegistrationsContainer.BeginLifetimeScope(configurationAction);
+            _managedChildScopes.Add(childScope);
 
-            _currentLifetimeScope.ChildLifetimeScopeBeginning += OnChildLifetimeScopeBeginning;
-            _currentLifetimeScope.CurrentScopeEnding += OnCurrentScopeEnding;
-            _currentLifetimeScope.ResolveOperationBeginning += OnResolveOperationBeginning;
+            // We need to re-add components back to the root scope.
+            // This is important so that the new registrations are available when resolving for example singletons that have not yet been resolved.
+            // Without this, singletons would not get any of the registrations done with RegisterTypes, even if they were resolved after additional registrations.
+            var registrationSource = new ExternalRegistrySource(childScope.ComponentRegistry);
+            _lifetimeScope.ComponentRegistry.AddRegistrationSource(registrationSource);
         }
 
         private void OnResolveOperationBeginning(object sender, ResolveOperationBeginningEventArgs e)
@@ -63,52 +63,53 @@ namespace Prism.Autofac.Mutable.Wpf.Ioc
 
         public ILifetimeScope BeginLifetimeScope()
         {
-            return _currentLifetimeScope.BeginLifetimeScope();
+            return _lifetimeScope.BeginLifetimeScope();
         }
 
         public ILifetimeScope BeginLifetimeScope(object tag)
         {
-            return _currentLifetimeScope.BeginLifetimeScope(tag);
+            return _lifetimeScope.BeginLifetimeScope(tag);
         }
 
         public ILifetimeScope BeginLifetimeScope(Action<ContainerBuilder> configurationAction)
         {
-            return _currentLifetimeScope.BeginLifetimeScope(configurationAction);
+            return _lifetimeScope.BeginLifetimeScope(configurationAction);
         }
 
         public ILifetimeScope BeginLifetimeScope(object tag, Action<ContainerBuilder> configurationAction)
         {
-            return _currentLifetimeScope.BeginLifetimeScope(tag, configurationAction);
+            return _lifetimeScope.BeginLifetimeScope(tag, configurationAction);
         }
-        
+
         public object ResolveComponent(IComponentRegistration registration, IEnumerable<Parameter> parameters)
         {
-            return _currentLifetimeScope.ResolveComponent(registration, parameters);
+            return _lifetimeScope.ResolveComponent(registration, parameters);
         }
 
-        public IComponentRegistry ComponentRegistry => _currentLifetimeScope.ComponentRegistry;
+        public IComponentRegistry ComponentRegistry => _lifetimeScope.ComponentRegistry;
 
-        
+
 
         protected override void Dispose(bool disposing)
         {
             if (disposing)
             {
                 _container.Dispose();
+                _additionalRegistrationsContainer.Dispose();
                 _managedChildScopes.ForEach(s => s.Dispose());
             }
             base.Dispose(disposing);
         }
 
-        public IDisposer Disposer => _currentLifetimeScope.Disposer;
-        public object Tag => _currentLifetimeScope.Tag;
+        public IDisposer Disposer => _lifetimeScope.Disposer;
+        public object Tag => _lifetimeScope.Tag;
         public event EventHandler<LifetimeScopeBeginningEventArgs> ChildLifetimeScopeBeginning;
         public event EventHandler<LifetimeScopeEndingEventArgs> CurrentScopeEnding;
         public event EventHandler<ResolveOperationBeginningEventArgs> ResolveOperationBeginning;
 
         public object GetService(Type serviceType)
         {
-            return ((IServiceProvider)_currentLifetimeScope).GetService(serviceType);
+            return ((IServiceProvider)_lifetimeScope).GetService(serviceType);
         }
     }
 }

--- a/Prism.Autofac.Mutable.Wpf/Prism.Autofac.Mutable.Wpf.csproj
+++ b/Prism.Autofac.Mutable.Wpf/Prism.Autofac.Mutable.Wpf.csproj
@@ -67,6 +67,7 @@
     <Compile Include="Ioc\AutofacContainerRegistryFinalizedException.cs" />
     <Compile Include="Ioc\AutofacContainerRegistry.cs" />
     <Compile Include="AutofacServiceLocatorAdapter.cs" />
+    <Compile Include="Ioc\ExternalRegistrySource.cs" />
     <Compile Include="Ioc\IAutofacContainerExtension.cs" />
     <Compile Include="Ioc\IAutofacContainerRegistry.cs" />
     <Compile Include="Ioc\IMutableContainer.cs" />

--- a/Tests/Prism.Autofac.Mutable.Wpf.Tests/MutableContainerFixture.cs
+++ b/Tests/Prism.Autofac.Mutable.Wpf.Tests/MutableContainerFixture.cs
@@ -14,9 +14,7 @@ namespace Prism.Autofac.Mutable.Wpf.Tests
         public void Initialize()
         {
             var builder = new ContainerBuilder();
-            var container = builder.Build();
-
-            _mutable = new MutableContainer(container);
+            _mutable = new MutableContainer(builder);
         }
 
 

--- a/Tests/Prism.Autofac.Mutable.Wpf.Tests/MutableContainerFixture.cs
+++ b/Tests/Prism.Autofac.Mutable.Wpf.Tests/MutableContainerFixture.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Autofac;
 using FluentAssertions;
 using NUnit.Framework;
@@ -14,16 +16,13 @@ namespace Prism.Autofac.Mutable.Wpf.Tests
         public void Initialize()
         {
             var builder = new ContainerBuilder();
+            builder.RegisterType<Singleton>().SingleInstance();
             _mutable = new MutableContainer(builder);
         }
 
-
         [Test]
-        public void MutableContainerShouldBeRegisteredAsAutofacComponents()
+        public void MutableContainerShouldBeRegisteredAsContainer()
         {
-
-            _mutable.Resolve<ILifetimeScope>().Should().Be(_mutable);
-            _mutable.Resolve<IComponentContext>().Should().Be(_mutable);
             _mutable.Resolve<IContainer>().Should().Be(_mutable);
         }
 
@@ -37,8 +36,6 @@ namespace Prism.Autofac.Mutable.Wpf.Tests
         public void MutableContainerShouldRetainSelfRegistrationsOnRegisterTypes()
         {
             _mutable.RegisterTypes(b => {});
-            _mutable.Resolve<ILifetimeScope>().Should().Be(_mutable);
-            _mutable.Resolve<IComponentContext>().Should().Be(_mutable);
             _mutable.Resolve<IContainer>().Should().Be(_mutable);
         }
 
@@ -56,6 +53,82 @@ namespace Prism.Autofac.Mutable.Wpf.Tests
             _mutable.Dispose();
             Action resolveAction = () => _mutable.Resolve<INewClassRegistration>();
             resolveAction.Should().Throw<ObjectDisposedException>();
+        }
+
+        [Test]
+        public void SingletonShouldGetAllRegistrationsWhenResolvedAfterNewRegistrations()
+        {
+            _mutable.RegisterTypes(builder =>
+            {
+                builder.RegisterType<NewClassRegistration>().As<INewClassRegistration>();
+                builder.RegisterType<NewClassRegistration>().As<INewClassRegistration>();
+                builder.RegisterType<NewClassRegistration>().As<INewClassRegistration>();
+            });
+            var singleton = _mutable.Resolve<Singleton>();
+            singleton.Registrations.Count().Should().Be(3);
+        }
+
+        [Test]
+        public void SingletonShouldNotGetAllRegistrationsWhenResolvedBeforeNewRegistrations()
+        {
+            var singleton = _mutable.Resolve<Singleton>();
+            singleton.Registrations.Count().Should().Be(0);
+            _mutable.RegisterTypes(builder =>
+            {
+                builder.RegisterType<NewClassRegistration>().As<INewClassRegistration>();
+                builder.RegisterType<NewClassRegistration>().As<INewClassRegistration>();
+                builder.RegisterType<NewClassRegistration>().As<INewClassRegistration>();
+            });
+            singleton = _mutable.Resolve<Singleton>();
+            singleton.Registrations.Count().Should().Be(0);
+        }
+
+        [Test]
+        public void LifetimeScopesResolvedInNewRegistrationsShouldReturnOriginalScope()
+        {
+            var scope = _mutable.Resolve<ILifetimeScope>();
+            _mutable.RegisterTypes(builder => builder.RegisterType<ClassWithLifetimeScope>());
+            var classWithScope = _mutable.Resolve<ClassWithLifetimeScope>();
+            classWithScope.Scope.Should().Be(scope);
+        }
+
+        [Test]
+        public void TypesInNewRegistrationsShouldBeAbleToResolveOriginalComponents()
+        {
+            var singleton = _mutable.Resolve<Singleton>();
+            _mutable.RegisterTypes(builder => builder.RegisterType<ClassWithSingleton>());
+            var classWithSingleton = _mutable.Resolve<ClassWithSingleton>();
+            classWithSingleton.Singleton.Should().Be(singleton);
+        }
+
+        private class ClassWithSingleton
+        {
+            public Singleton Singleton { get; }
+
+            public ClassWithSingleton(Singleton singleton)
+            {
+                Singleton = singleton;
+            }
+        }
+
+        private class ClassWithLifetimeScope
+        {
+            public ILifetimeScope Scope { get; }
+
+            public ClassWithLifetimeScope(ILifetimeScope scope)
+            {
+                Scope = scope;
+            }
+        }
+
+        private class Singleton
+        {
+            public IEnumerable<INewClassRegistration> Registrations { get; }
+
+            public Singleton(IEnumerable<INewClassRegistration> registrations)
+            {
+                Registrations = registrations;
+            }
         }
 
         private class NewClassRegistration : INewClassRegistration


### PR DESCRIPTION
Fixes #1 

## Proposed Changes
- Mutability is now achieved using a set of `IRegistrationSource`s instead of through `BeginLifetimeScope`. When registering new components in modules, `MutableContainer` will create a new container and make its components available in the original container through `ExternalRegistrySource`.